### PR TITLE
Cross compile to scala `2.10.7`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,12 @@
 scalaVersion := "2.12.7"
-crossScalaVersions ++= List("2.11.12", "2.12.1", "2.12.2", "2.12.3", "2.12.4", "2.12.5", "2.12.6")
+crossScalaVersions ++= List("2.10.7","2.11.12", "2.12.1", "2.12.2", "2.12.3", "2.12.4", "2.12.5", "2.12.6")
 crossVersion := CrossVersion.full
 organization := "io.tryp"
 name := "splain"
 fork := true
 libraryDependencies ++= List(
   scalaOrganization.value % "scala-compiler" % scalaVersion.value % "provided",
-  "org.specs2" %% "specs2-core" % "4.1.0" % "test",
+  "org.specs2" %% "specs2-core" % "3.9.5" % "test",
   "com.chuusai" %% "shapeless" % "2.3.3" % "test",
 )
 


### PR DESCRIPTION
Bumping down specs2-core to `3.9.5` is necessary as `4.x` is not supported for scala `2.10.x`

We are using scala 2.10.x and it seems to work by only doing this, let me know if this breaks something, tests are still passing.

Thanks for the great plugin, very useful !