### PR TITLE
Respect -Ymacro-annotations flag

### DIFF
--- a/src/main/scala-2.12/splain/SplainPluginCompat.scala
+++ b/src/main/scala-2.12/splain/SplainPluginCompat.scala
@@ -1,0 +1,20 @@
+package splain
+
+abstract class SplainPluginCompat extends SplainPluginLike {
+
+  val analyzer =
+    new { val global = SplainPluginCompat.this.global } with Analyzer {
+      def featureImplicits = boolean(keyImplicits)
+      def featureFoundReq = boolean(keyFoundReq)
+      def featureInfix = boolean(keyInfix)
+      def featureBounds = boolean(keyBounds)
+      def featureColor = boolean(keyColor)
+      def featureBreakInfix = int(keyBreakInfix).filterNot(_ == 0)
+      def featureCompact = boolean(keyCompact)
+      def featureTree = boolean(keyTree)
+      def featureBoundsImplicits = boolean(keyBoundsImplicits)
+      def featureTruncRefined = int(keyTruncRefined).filterNot(_ == 0)
+      def featureRewrite = opt(keyRewrite, "")
+      def featureKeepModules = int(keyKeepModules).getOrElse(0)
+    }
+}

--- a/src/main/scala-2.13/splain/SplainPluginCompat.scala
+++ b/src/main/scala-2.13/splain/SplainPluginCompat.scala
@@ -1,0 +1,27 @@
+package splain
+
+import scala.tools.nsc._
+
+abstract class SplainPluginCompat extends SplainPluginLike {
+
+  trait Features {
+    def featureImplicits = boolean(keyImplicits)
+    def featureFoundReq = boolean(keyFoundReq)
+    def featureInfix = boolean(keyInfix)
+    def featureBounds = boolean(keyBounds)
+    def featureColor = boolean(keyColor)
+    def featureBreakInfix = int(keyBreakInfix).filterNot(_ == 0)
+    def featureCompact = boolean(keyCompact)
+    def featureTree = boolean(keyTree)
+    def featureBoundsImplicits = boolean(keyBoundsImplicits)
+    def featureTruncRefined = int(keyTruncRefined).filterNot(_ == 0)
+    def featureRewrite = opt(keyRewrite, "")
+    def featureKeepModules = int(keyKeepModules).getOrElse(0)
+  }
+
+  val analyzer = if (global.settings.YmacroAnnotations) {
+    new { val global = SplainPluginCompat.this.global } with Analyzer with typechecker.MacroAnnotationNamers with Features
+  } else {
+    new { val global = SplainPluginCompat.this.global } with Analyzer with Features
+  }
+}

--- a/src/main/scala/splain/SplainPlugin.scala
+++ b/src/main/scala/splain/SplainPlugin.scala
@@ -6,21 +6,27 @@ import scala.tools.nsc._
 class SplainPlugin(val global: Global)
 extends plugins.Plugin
 {
-  val analyzer =
-    new { val global = SplainPlugin.this.global } with Analyzer {
-      def featureImplicits = boolean(keyImplicits)
-      def featureFoundReq = boolean(keyFoundReq)
-      def featureInfix = boolean(keyInfix)
-      def featureBounds = boolean(keyBounds)
-      def featureColor = boolean(keyColor)
-      def featureBreakInfix = int(keyBreakInfix).filterNot(_ == 0)
-      def featureCompact = boolean(keyCompact)
-      def featureTree = boolean(keyTree)
-      def featureBoundsImplicits = boolean(keyBoundsImplicits)
-      def featureTruncRefined = int(keyTruncRefined).filterNot(_ == 0)
-      def featureRewrite = opt(keyRewrite, "")
-      def featureKeepModules = int(keyKeepModules).getOrElse(0)
-    }
+
+  trait Features {
+    def featureImplicits = boolean(keyImplicits)
+    def featureFoundReq = boolean(keyFoundReq)
+    def featureInfix = boolean(keyInfix)
+    def featureBounds = boolean(keyBounds)
+    def featureColor = boolean(keyColor)
+    def featureBreakInfix = int(keyBreakInfix).filterNot(_ == 0)
+    def featureCompact = boolean(keyCompact)
+    def featureTree = boolean(keyTree)
+    def featureBoundsImplicits = boolean(keyBoundsImplicits)
+    def featureTruncRefined = int(keyTruncRefined).filterNot(_ == 0)
+    def featureRewrite = opt(keyRewrite, "")
+    def featureKeepModules = int(keyKeepModules).getOrElse(0)
+  }
+
+  val analyzer = if (global.settings.YmacroAnnotations) {
+    new { val global = SplainPlugin.this.global } with Analyzer with typechecker.MacroAnnotationNamers with Features
+  } else {
+    new { val global = SplainPlugin.this.global } with Analyzer with Features
+  }
 
   val analyzerField = classOf[Global].getDeclaredField("analyzer")
   analyzerField.setAccessible(true)


### PR DESCRIPTION
closes #30 

PR adjusts the `analyzer`, to match the Scala compiler definition:

https://github.com/scala/scala/blob/2.13.x/src/compiler/scala/tools/nsc/Global.scala#L481-L483

```
  lazy val analyzer =
    if (settings.YmacroAnnotations) new { val global: Global.this.type = Global.this } with Analyzer with MacroAnnotationNamers
    else new { val global: Global.this.type = Global.this } with Analyzer
```