### PR TITLE
#43 - part 1

### DIFF
--- a/tests/byname-higher/code.scala
+++ b/tests/byname-higher/code.scala
@@ -3,5 +3,5 @@ object Foo
   type A
   type B
   def f(g: (=> A) => B): Unit = ()
-  f(1)
+  f(1: Int)
 }

--- a/tests/disambiguate/code.scala
+++ b/tests/disambiguate/code.scala
@@ -22,5 +22,5 @@ object A
   }
   def f(a: B.X.Y.T): Unit = ()
   val x: C.X.Y.T = ???
-  f(x)
+  f(x: C.X.Y.T)
 }

--- a/tests/single-fn/code.scala
+++ b/tests/single-fn/code.scala
@@ -1,0 +1,12 @@
+import shapeless._
+import shapeless.ops.hlist._
+
+object SingleImp
+{
+  def fn(): Unit= {
+    val a = 1
+    val b = 2
+
+    implicitly[a.type *** b.type]
+  }
+}

--- a/tests/single-fn/error
+++ b/tests/single-fn/error
@@ -1,0 +1,2 @@
+implicit error;
+!I e: a.type *** b.type

--- a/tests/single-free/code.scala
+++ b/tests/single-free/code.scala
@@ -1,0 +1,10 @@
+import shapeless._
+import shapeless.ops.hlist._
+
+object SingleImp
+{
+  def fn[A, B](a: A, b: B) = {
+
+    implicitly[a.type *** b.type]
+  }
+}

--- a/tests/single-free/error
+++ b/tests/single-free/error
@@ -1,0 +1,2 @@
+implicit error;
+!I e: a.type *** b.type

--- a/tests/single/code.scala
+++ b/tests/single/code.scala
@@ -1,0 +1,10 @@
+import shapeless._
+import shapeless.ops.hlist._
+
+object SingleImp
+{
+  val a = 1
+  val b = 2
+
+  implicitly[a.type *** b.type]
+}

--- a/tests/single/error
+++ b/tests/single/error
@@ -1,0 +1,2 @@
+implicit error;
+!I e: a.type *** b.type

--- a/tests/tuple1/code.scala
+++ b/tests/tuple1/code.scala
@@ -1,4 +1,4 @@
 object Tup1
 {
-  val a: Tuple1[String] = "Tuple1"
+  val a: Tuple1[String] = "Tuple1": String
 }

--- a/tests/witness-value/code.scala
+++ b/tests/witness-value/code.scala
@@ -1,0 +1,9 @@
+import shapeless._
+import shapeless.ops.hlist._
+
+object WitnessImp
+{
+  def fn[A, B](a: A, b: B)(implicit ev: A *** B) = ???
+
+  fn(Witness(3).value, Witness(4).value)
+}

--- a/tests/witness-value/error
+++ b/tests/witness-value/error
@@ -1,0 +1,2 @@
+implicit error;
+!I ev: Int(3) *** Int(4)


### PR DESCRIPTION
add 4 test cases for singleton & witness value types

base and plugin now defaults to default tests and bytecode directories, allowing tests to be run in IDE

add special handling for SingletonType (for displaying term.type) & RefinedType (for displaying Witness value type)