### PR TITLE
Support for zio layers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ fork := true
 libraryDependencies ++= List(
   scalaOrganization.value % "scala-compiler" % scalaVersion.value % "provided",
   "com.chuusai" %% "shapeless" % "2.3.3" % "test",
+  "dev.zio" %% "zio" % "1.0.4" % "test"
 )
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "4.5.1" % Test

--- a/src/test/scala/splain/ErrorsSpec.scala
+++ b/src/test/scala/splain/ErrorsSpec.scala
@@ -115,6 +115,7 @@ class ErrorsSpec extends SpecBase {
   single types in function ${checkError("single-fn")}
   single types with free symbol ${checkError("single-free")}
   witness value types ${checkError("witness-value")}
+  zio test ${checkError("zlayer")}
   """
 
 //  def is = s2"""

--- a/tests/zlayer/code.scala
+++ b/tests/zlayer/code.scala
@@ -1,0 +1,20 @@
+import zio._
+
+object layers {
+
+  trait Service1
+  trait Service2
+  trait Service3
+  trait Service4
+
+  val service1 = ZLayer.succeed(new Service1 {})
+
+  val service2 = ZLayer.succeed(new Service2 {})
+
+  val service3 = ZLayer.fromService { (_: Service1) => new Service3 {} }
+
+  val service4 = ZLayer.succeed(new Service4 {})
+
+  val services: ULayer[Has[Service1] with Has[Service2] with Has[Service3] with Has[Service4]] =
+    service1 ++ service2 >+> service3// ++ service4
+}

--- a/tests/zlayer/error
+++ b/tests/zlayer/error
@@ -1,0 +1,2 @@
+type mismatch;
+  ZLayer[, Nothing, <none>|Has[Service4] with Has[Service1] with Has[Service2] with Has[Service3]]


### PR DESCRIPTION
Using [ZLayers](https://zio.dev/docs/datatypes/datatypes_zlayer) from zio leads to unreadable compilation messages when environment misses some layer. This plugin can greatly improve error messages. `RefinedFormatter` already does most of work but small changes are needed.

`RefinedFormatter` collects traits only from top level while zlayers can have nested `RefinedType`s. Here is example from my test
```scala
RefinedType(List(
  RefinedType(List(
    TypeRef(ThisType(zio), zio.Has, List(
      RefinedType(List(TypeRef(ThisType(scala), TypeName("AnyRef"), List()), TypeRef(ThisType(layers), layers.Service1, List())), Scope())
    )),
    TypeRef(ThisType(zio), zio.Has, List(
      RefinedType(List(TypeRef(ThisType(scala), TypeName("AnyRef"), List()), TypeRef(ThisType(layers), layers.Service2, List())), Scope())
    ))
  ), Scope()),
  TypeRef(ThisType(zio), zio.Has, List(
    RefinedType(List(TypeRef(ThisType(scala), TypeName("AnyRef"), List()), TypeRef(ThisType(layers), layers.Service3, List())), Scope())
  ))
), Scope())
```
It has several levels of `RefinedType`s and services are on bottom level. This is why I added class `DeepRefined`.

There is another issue with this syntax tree which breaks error reporting. Compiler defines type of services as `zio.Has[AnyRef with layers.Service1]` which is equivalent to `zio.Has[layers.Service1]`. So I was needed to handle this case inside `DeepRefined` and remove `AnyRef` inside `zio.Has`.

What do you think about these changes? Can I add some new option for plugin which allows to replace default `Refined` by `DeepRefined`?


