### PR TITLE
add github action strategy matrix to run compilation & test for all supported scala versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,11 +7,30 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      max-parallel: 2
+      fail-fast: false
+      matrix:
+        version: [
+            "2.12.5","2.12.6","2.12.7","2.12.8","2.12.9","2.12.10","2.12.11","2.12.12","2.12.13","2.12.14",
+            "2.13.1","2.13.2","2.13.3","2.13.4","2.13.5"
+        ]
+
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Run tests
-        run: sbt clean publishM2 test
+      - name: Compile
+        run: sbt ++${{matrix.version}} clean publishM2
+      - name: Test
+        run: sbt ++${{matrix.version}} test
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: |
+            **/test-reports/*.xml
+          check_name: |
+            Test Report (${{matrix.version}})


### PR DESCRIPTION
voila, also publish the testing result for each scala minor version

this is blocking a patch for scala 2.13.6+ and scala 2.12.14+