### PR TITLE
This is a fix for a bug I introduced, which caused control characters in implicit annotations to spoil the output format

### DIFF
--- a/core/src/main/scala-2.13.6+/splain/SplainFormattingExtension.scala
+++ b/core/src/main/scala-2.13.6+/splain/SplainFormattingExtension.scala
@@ -109,11 +109,14 @@ trait SplainFormattingExtension extends typechecker.splain.SplainFormatting with
 
     val treeNodes = ImplicitErrorTree.fromChildren(errors, -1)
 
-    val result =
-      s"""
-         |implicit error;
-         |${(implicitMessage(param, annotationMsg) ++ treeNodes).mkString("\n")}
-         |""".stripMargin.trim
+    val msg = implicitMessage(param, annotationMsg)
+
+    val components =
+      Seq("implicit error;") ++
+        implicitMessage(param, annotationMsg) ++
+        treeNodes
+
+    val result = components.mkString("\n")
 
     result
   }

--- a/core/src/test/resources/splain/builtin/BasicSpec/__direct/check
+++ b/core/src/test/resources/splain/builtin/BasicSpec/__direct/check
@@ -33,6 +33,7 @@ newSource1.scala:4: error: implicit error;
   the following:
 
   implicit val ec: scala.concurrent.ExecutionContext = scala.concurrent.ExecutionContext.global
+
   long
   ^
 newSource1.scala:10: error: implicit error;

--- a/core/src/test/resources/splain/plugin/PluginSpec/implicit-ctrl-char/code.scala
+++ b/core/src/test/resources/splain/plugin/PluginSpec/implicit-ctrl-char/code.scala
@@ -1,0 +1,18 @@
+import scala.annotation.implicitNotFound
+
+object Annotation {
+
+  trait Arg
+
+  @implicitNotFound("A\n   | B\n  | C")
+  trait F[A]
+
+  trait G[A]
+
+  implicit def f[A](
+      implicit
+      ev: F[A]
+  ): G[A] = ???
+
+  implicitly[G[Arg]]
+}

--- a/core/src/test/resources/splain/plugin/PluginSpec/implicit-ctrl-char/error
+++ b/core/src/test/resources/splain/plugin/PluginSpec/implicit-ctrl-char/error
@@ -1,0 +1,10 @@
+newSource1.scala:25: error: implicit error;
+!I e: G[Arg]
+Annotation.f invalid because
+!I ev: F[Arg]
+  A
+     | B
+    | C
+
+  implicitly[G[Arg]]
+            ^

--- a/core/src/test/scala/splain/plugin/PluginSpec.scala
+++ b/core/src/test/scala/splain/plugin/PluginSpec.scala
@@ -45,13 +45,15 @@ class PluginSpec extends SpecBase.File {
     checkError()
   }
 
-  check("tree", extra = "-P:splain:tree") {
-    checkError()
-  }
+  describe("tree printing") {
+    check("tree", extra = "-P:splain:tree") {
+      checkError()
+    }
 
-  // TODO: what's the new args?
-  skip("compact tree printing", "tree", extra = "-P:splain:tree -P:splain:compact") {
-    checkError(Some("errorCompact"))
+    // TODO: what's the new args?
+    skip("compact", "tree", extra = "-P:splain:tree -P:splain:compact") {
+      checkError(Some("errorCompact"))
+    }
   }
 
   //  TODO: what's the new args?
@@ -84,15 +86,22 @@ class PluginSpec extends SpecBase.File {
     checkError()
   }
 
-  check("single types", "single") {
-    checkError()
+  describe("single types ") {
+
+    check("single") {
+      checkError()
+    }
+
+    check("in function", "single-fn") {
+      checkError()
+    }
+
+    check("with free symbol", "single-free") {
+      checkError()
+    }
   }
 
-  check("single types in function", "single-fn") {
-    checkError()
-  }
-
-  check("single types with free symbol", "single-free") {
+  check("implicit annotation with control character(s)", "implicit-ctrl-char") {
     checkError()
   }
 


### PR DESCRIPTION
voila