### PR TITLE
Fix for bug #88

### DIFF
--- a/core/src/main/scala-2.13.6+/latest/splain/ImplicitsExtension.scala
+++ b/core/src/main/scala-2.13.6+/latest/splain/ImplicitsExtension.scala
@@ -20,14 +20,14 @@ trait ImplicitsExtension extends typechecker.Implicits {
 
   object ImplicitHistory {
 
-    @volatile protected var _currentGlobal: Global = _
+    @volatile protected var _currentGlobalHistory: GlobalHistory = _
 
-    case class Global() {
+    case class GlobalHistory() {
 
-      val byPosition = mutable.HashMap.empty[PositionIndex, Local]
+      val byPosition = mutable.HashMap.empty[PositionIndex, LocalHistory]
     }
 
-    case class Local() {
+    case class LocalHistory() {
 
       object DivergingImplicitErrors {
 
@@ -63,10 +63,10 @@ trait ImplicitsExtension extends typechecker.Implicits {
         pos: Position
     ) {}
 
-    def currentGlobal: Global = Option(_currentGlobal).getOrElse {
+    def currentGlobal: GlobalHistory = Option(_currentGlobalHistory).getOrElse {
       ImplicitHistory.synchronized {
-        val result = Global()
-        _currentGlobal = result
+        val result = GlobalHistory()
+        _currentGlobalHistory = result
         result
       }
     }
@@ -92,7 +92,7 @@ trait ImplicitsExtension extends typechecker.Implicits {
         tree.pos
       )
 
-      val local = currentGlobal.byPosition.getOrElseUpdate(posII, Local())
+      val local = currentGlobal.byPosition.getOrElseUpdate(posII, LocalHistory())
       val previousSimilarErrors = local.DivergingImplicitErrors.errors.filter { ee =>
         ee.underlyingTree equalsStructure tree
       }

--- a/core/src/test/resources-2.13.6+/2.13.6/splain/plugin/DivergingSpec/diverging-compact/code.scala
+++ b/core/src/test/resources-2.13.6+/2.13.6/splain/plugin/DivergingSpec/diverging-compact/code.scala
@@ -1,0 +1,18 @@
+object DivergingImplicits {
+
+  type C
+  type D
+
+  object Diverging {
+    trait ::[A, B]
+
+    implicit def f[A, B](
+        implicit
+        ii: Int :: A :: B
+    ): A :: B = ???
+
+    implicit def g[A, B]: Int :: Int :: Int :: A :: B = ???
+
+    implicitly[C :: D]
+  }
+}

--- a/core/src/test/resources-2.13.6+/2.13.6/splain/plugin/DivergingSpec/diverging-compact/error
+++ b/core/src/test/resources-2.13.6+/2.13.6/splain/plugin/DivergingSpec/diverging-compact/error
@@ -1,0 +1,11 @@
+newSource1.scala:16: error: implicit error;
+!I e: C :: D
+Diverging.f invalid because
+!I ii: Int :: C :: D
+⋮
+――Diverging.f invalid because
+  !I ii: Int :: Int :: Int :: C :: D
+  diverging implicit expansion for type (Int :: Int :: Int :: C :: D)
+  starting with method g in object Diverging
+    implicitly[C :: D]
+              ^

--- a/core/src/test/resources-2.13.7+/latest/splain/plugin/DivergingSpec/diverging-compact/code.scala
+++ b/core/src/test/resources-2.13.7+/latest/splain/plugin/DivergingSpec/diverging-compact/code.scala
@@ -1,0 +1,18 @@
+object DivergingImplicits {
+
+  type C
+  type D
+
+  object Diverging {
+    trait ::[A, B]
+
+    implicit def f[A, B](
+        implicit
+        ii: Int :: A :: B
+    ): A :: B = ???
+
+    implicit def g[A, B]: Int :: Int :: Int :: A :: B = ???
+
+    implicitly[C :: D]
+  }
+}

--- a/core/src/test/resources-2.13.7+/latest/splain/plugin/DivergingSpec/diverging-compact/error
+++ b/core/src/test/resources-2.13.7+/latest/splain/plugin/DivergingSpec/diverging-compact/error
@@ -1,0 +1,16 @@
+newSource1.scala:16: error: implicit error;
+!I e: DivergingImplicits.C :: DivergingImplicits.D
+Diverging.f invalid because
+!I ii: scala.Int :: DivergingImplicits.C :: DivergingImplicits.D
+⋮
+――Diverging.f invalid because
+  !I ii:
+    scala.Int ::
+    scala.Int ::
+    scala.Int ::
+    DivergingImplicits.C ::
+    DivergingImplicits.D
+  diverging implicit expansion for type (scala.Int :: scala.Int :: scala.Int :: DivergingImplicits.C :: DivergingImplicits.D)
+  starting with method g in object Diverging
+    implicitly[C :: D]
+              ^

--- a/core/src/test/scala/splain/SpecBase.scala
+++ b/core/src/test/scala/splain/SpecBase.scala
@@ -16,18 +16,6 @@ object SpecBase {
     // will use reflection to discover all type `() => String` method under this instance
     lazy val codeToName: Map[String, String] = {
 
-//      val allFields = this.getClass.getDeclaredFields
-//      val fields = allFields.filter { field =>
-//        field.getType == classOf[String]
-//      }
-//
-//      val fieldSeq = fields.flatMap { field =>
-//        Try {
-//          val code = field.get(this).asInstanceOf[String]
-//          code -> field.getName
-//        }.toOption
-//      }
-
       val allMethods = this.getClass.getMethods
       val methods = allMethods.filter { method =>
         method.getParameterCount == 0 &&

--- a/core/src/test/scala/splain/plugin/DivergingSpec.scala
+++ b/core/src/test/scala/splain/plugin/DivergingSpec.scala
@@ -4,7 +4,9 @@ import splain.SpecBase
 
 class DivergingSpec extends SpecBase.File {
 
-  override lazy val defaultExtra: String = "-P:splain:Vimplicits-diverging"
+  override protected lazy val specCompilerOptions = "-Vimplicits -Vtype-diffs"
+
+  override lazy val defaultExtra: String = "-Vimplicits-verbose-tree -P:splain:Vimplicits-diverging"
 
   check("self") {
     checkError()
@@ -27,6 +29,10 @@ class DivergingSpec extends SpecBase.File {
   }
 
   check("diverging") {
+    checkError()
+  }
+
+  check("... without verbose-tree", "diverging-compact", extra = "-P:splain:Vimplicits-diverging") {
     checkError()
   }
 }


### PR DESCRIPTION
FormattedChain is now shorter and a case class

formatImplicitChainTreeFull is now cased in ErrorNode. And executed on creation to trigger the side effect of linking