### PR TITLE
Fix SerializingLift.asCode for case objects

### DIFF
--- a/core/src/main/scala/splain/test/AutoLift.scala
+++ b/core/src/main/scala/splain/test/AutoLift.scala
@@ -54,7 +54,12 @@ object AutoLift {
       }
         .mkString("(", ", ", ")")
 
-      val typeStr = value.getClass.getCanonicalName.stripSuffix("$")
+      val typeStr = {
+        val canonicalName = value.getClass.getCanonicalName
+        if (canonicalName.endsWith("$"))
+          canonicalName.stripSuffix("$") + ".type"
+        else canonicalName
+      }
 
       val result = s"""
          |$fullPath.fromPreviousStage[$typeStr]$chunkExpr


### PR DESCRIPTION
If `value` is a case object, it's not enough to strip the dollar suffix, it's necessary to add `.type` to have an object type.

Discovered in https://stackoverflow.com/questions/62458950/how-to-use-quasiquotes-with-previously-defined-object