### PR TITLE
Add DiffDisambiguationFormatter

### DIFF
--- a/core/src/main/scala-2.13.7+/latest/splain/SplainAnalyzer.scala
+++ b/core/src/main/scala-2.13.7+/latest/splain/SplainAnalyzer.scala
@@ -15,6 +15,7 @@ class SplainAnalyzer(val global: Global, val pluginSettings: PluginSettings)
       ShapelessRecordItemFormatter,
       RefinedFormatterImproved,
 //      RefinedFormatter,
-      ByNameFormatter
+      ByNameFormatter,
+      DiffDisambiguationFormatter
     )
 }

--- a/core/src/main/scala-2.13.7+/latest/splain/SplainFormattersExtension.scala
+++ b/core/src/main/scala-2.13.7+/latest/splain/SplainFormattersExtension.scala
@@ -228,4 +228,52 @@ trait SplainFormattersExtension extends SplainFormatters {
       }
     }
   }
+
+  object DiffDisambiguationFormatter extends SpecialFormatter {
+
+    override def apply[A](
+        tpe: Type,
+        simple: String,
+        args: List[A],
+        formattedArgs: => List[Formatted],
+        top: Boolean
+    )(rec: (A, Boolean) => Formatted): Option[Formatted] = None
+
+    override def diff(
+        left: Type,
+        right: Type,
+        top: Boolean
+    ): Option[Formatted] = {
+
+      val original = formatDiffSimple(left, right)
+
+      original match {
+        case Diff(lf, rf) =>
+          val sameResult = lf == rf
+          val diff = TypeDiffView(left, right)
+          val easilyMistakable = diff.easilyMistakable
+
+          if (left != right && (sameResult || easilyMistakable)) {
+
+            val refined = diff.toTuple { tt =>
+              RefinedForm(
+                lf :: Nil,
+                Simple(
+                  SimpleName(
+                    TypeView(tt).prefixContext
+                  )
+                ) :: Nil
+              )
+            }
+
+            val result = Diff(refined._1, refined._2)
+            Some(result)
+          } else None
+
+        case _ =>
+          None
+      }
+
+    }
+  }
 }

--- a/core/src/test/resources/splain/plugin/DiffDisambiguationSpec/__direct/check
+++ b/core/src/test/resources/splain/plugin/DiffDisambiguationSpec/__direct/check
@@ -1,0 +1,8 @@
+newSource1.scala:6: error: type mismatch;
+  Long {in <none>}|Long {in scala}
+        else add2(x.head, y.head) :: add(x.tail, y.tail)
+                    ^
+newSource1.scala:6: error: type mismatch;
+  Long {in <none>}|Long {in scala}
+        else add2(x.head, y.head) :: add(x.tail, y.tail)
+                            ^

--- a/core/src/test/scala/splain/plugin/DiffDisambiguationSpec.scala
+++ b/core/src/test/scala/splain/plugin/DiffDisambiguationSpec.scala
@@ -1,0 +1,19 @@
+package splain.plugin
+
+import splain.SpecBase
+
+class DiffDisambiguationSpec extends SpecBase.Direct {
+
+  final val basic =
+    """
+    object Test {
+      def add2(x:Long,y:Long): Long = x + y
+
+      def add[Long](x: List[Long], y: List[Long]): List[Long] =
+        if (x.isEmpty || y.isEmpty) Nil
+        else add2(x.head, y.head) :: add(x.tail, y.tail)
+    }
+"""
+
+  check(basic, numberOfErrors = 2)
+}


### PR DESCRIPTION
The new formatter will add prefix context to type diff if it is not strong enough to show the difference. E.g. the following error:

```
newSource1.scala:6: error: type mismatch;
  Long|Long
        else add2(x.head, y.head) :: add(x.tail, y.tail)
                    ^
```

will become

```
newSource1.scala:6: error: type mismatch;
  Long {in <none>}|Long {in scala}
        else add2(x.head, y.head) :: add(x.tail, y.tail)
                    ^
```